### PR TITLE
Run linting through NPM

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -25,6 +25,16 @@ pipeline:
         - push
         - tag
 
+  lint_nodejs:
+    image: node:8-alpine
+    commands:
+      - apk add --no-cache make
+      - make node-lint
+    when:
+      event:
+        - push
+        - tag
+
   test_nodejs:
     image: node:8-alpine
     commands:

--- a/.drone.yml
+++ b/.drone.yml
@@ -25,16 +25,6 @@ pipeline:
         - push
         - tag
 
-  lint_nodejs:
-    image: node:8-alpine
-    commands:
-      - apk add --no-cache make
-      - make node-lint
-    when:
-      event:
-        - push
-        - tag
-
   test_nodejs:
     image: node:8-alpine
     commands:

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ tropo-test:
 	PYTHONPATH=src python -m pytest --rootdir=test
 
 ./lambda-src/node_modules/:
-	cd lambda-src && npm install 
+	cd lambda-src && npm install
 	cd lambda-src && npm install --only=dev
 
 tropo-lint:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build check-env clean delete-stack package rebuild tropo-test node-test tropo-lint node-lint venv
+.PHONY: build check-env clean delete-stack package rebuild tropo-test node-test tropo-lint node-lint node-lint-fix venv
 
 all: package
 

--- a/Makefile
+++ b/Makefile
@@ -34,12 +34,10 @@ node-test: ./lambda-src/node_modules/
 	cd lambda-src && npm test
 
 node-lint: ./lambda-src/node_modules/
-	./lambda-src/node_modules/.bin/standard lambda-src/*.js
-	./lambda-src/node_modules/.bin/standard --env mocha test/*.js
+	cd lambda-src && npm run lint
 
 node-lint-fix: ./lambda-src/node_modules/
-	./lambda-src/node_modules/.bin/standard --fix lambda-src/*.js
-	./lambda-src/node_modules/.bin/standard --fix --env mocha test/*.js
+	cd lambda-src && npm run lint-fix
 
 delete-stack:
 	aws cloudformation delete-stack --stack-name budget-alerts

--- a/lambda-src/package.json
+++ b/lambda-src/package.json
@@ -4,7 +4,8 @@
   "description": "Sends a message to a Slack channel",
   "main": "index.js",
   "scripts": {
-    "test": "npm run lint && npm run test:unit",
+    "test:all": "npm run lint && npm run test:unit",
+    "test": "npm run test:unit",
     "test:unit": "mocha -u bdd --timeout 999999 --colors ../test",
     "lint": "npm run lint:src && npm run lint:test",
     "lint-fix": "npm run lint-fix:src && npm run lint-fix:test",

--- a/lambda-src/package.json
+++ b/lambda-src/package.json
@@ -4,7 +4,14 @@
   "description": "Sends a message to a Slack channel",
   "main": "index.js",
   "scripts": {
-    "test": "mocha -u bdd --timeout 999999 --colors ../test"
+    "test": "npm run lint && npm run test:unit",
+    "test:unit": "mocha -u bdd --timeout 999999 --colors ../test",
+    "lint": "npm run lint:src && npm run lint:test",
+    "lint-fix": "npm run lint-fix:src && npm run lint-fix:test",
+    "lint:src": "standard *.js",
+    "lint:test": "standard --env mocha ../test/*.js",
+    "lint-fix:src": "standard --fix *.js",
+    "lint-fix:test": "standard --fix --env mocha ../test/*.js"
   },
   "author": "Home Office CDP team",
   "license": "MIT",


### PR DESCRIPTION
```
npm run lint
```

This also makes it so that `npm test` will run the linter prior to executing the unit tests. (As linting is usually quicker.)