### PR TITLE
specify dataclasses in requirements file as it is a 3.7 feature

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ troposphere==2.4.6
 pytest==4.5.0
 pylint
 botocore==1.12.145
+dataclasses==0.6


### PR DESCRIPTION
and lambda currently runs 3.6